### PR TITLE
fix: --quiet flag was ignored

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function startMaster() {
     )
     .option('--write', 'Whether to write files to the output')
     .option('--concurrency [value]', 'Maximum concurrency', cpus().length)
-    .option('--quiet, -q', 'If set, pprettier will not output progress')
+    .option('-q, --quiet', 'If set, pprettier will not output progress')
     .version(`@mixer/parallel-prettier version ${version} / prettier version ${prettier.version}`)
     .parse(process.argv);
 


### PR DESCRIPTION
`pprettier --quiet` and `pprettier -q` do not do anything.

`commander.js` seems unhappy with this syntax, although I don't get why.

Use the syntax as in the manual, and it works.